### PR TITLE
Bug fixes in the IPMX-testing branch

### DIFF
--- a/nmostesting/MulticastUtils.py
+++ b/nmostesting/MulticastUtils.py
@@ -63,12 +63,6 @@ IP_ADAPTER_ADDRESSES._fields_ = [
     ("PhysicalAddressLength", ctypes.c_ulong),
 ]
 
-GetAdaptersAddresses = ctypes.windll.iphlpapi.GetAdaptersAddresses
-GetAdaptersAddresses.argtypes = [
-    ctypes.c_ulong, ctypes.c_ulong, ctypes.c_void_p,
-    LP_IP_ADAPTER_ADDRESSES, ctypes.POINTER(ctypes.c_ulong)
-]
-
 GAA_FLAG_SKIP_ANYCAST   = 0x2
 GAA_FLAG_SKIP_MULTICAST = 0x4
 GAA_FLAG_SKIP_DNS_SERVER= 0x8
@@ -87,6 +81,11 @@ class MulticastUtils:
     # -----------------------------
     @staticmethod
     def get_windows_adapters():
+        GetAdaptersAddresses = ctypes.windll.iphlpapi.GetAdaptersAddresses
+        GetAdaptersAddresses.argtypes = [
+            ctypes.c_ulong, ctypes.c_ulong, ctypes.c_void_p,
+            LP_IP_ADAPTER_ADDRESSES, ctypes.POINTER(ctypes.c_ulong)
+        ]
         size = ctypes.c_ulong(16384)
         while True:
             buf = ctypes.create_string_buffer(size.value)

--- a/nmostesting/suites/IpmxSdpTest.py
+++ b/nmostesting/suites/IpmxSdpTest.py
@@ -275,7 +275,7 @@ class IpmxSdpTest(GenericTest):
 
             found_initial_data_set = False
 
-            while True:
+            while not found_initial_data_set:
                 if websocket.did_error_occur():
                     return test.FAIL("Error opening websocket: {}".format(websocket.get_error_message()))
 
@@ -288,7 +288,6 @@ class IpmxSdpTest(GenericTest):
                     json_msg = json.loads(curr_msg)
                     grain_data.extend(json_msg["grain"]["data"])
 
-                found_data_set = False
                 for curr_data in grain_data:
 
                     # case has Pre && has Post:
@@ -307,13 +306,8 @@ class IpmxSdpTest(GenericTest):
                         continue
 
                     if sender_id == curr_data['path']:
-                        found_data_set = True
+                        found_initial_data_set = True
                         break
-
-                if found_data_set:
-                    if found_initial_data_set:
-                        break
-                    found_initial_data_set = True
 
             # Now check for the SDP transport file every 500 ms for 10 seconds
             iterations = 10000/100


### PR DESCRIPTION
1. Fixed a test that may have gone into an infinite loop. Simplified the loop logic so that it exits when the exit condition has been met.
2. Moved an invocation to `ctypes.windll` into the `get_windows_adapters` in order to allow this tool to work in Docker on Linux.

Please see commit messages for more info.
Thank you!