### PR TITLE
13.3b fix

### DIFF
--- a/TP-10-1Sec13.3b.py
+++ b/TP-10-1Sec13.3b.py
@@ -176,7 +176,7 @@ def try_parse_rtp(b: bytes) -> Optional[Tuple[int, int]]:
     if not b or len(b) < 12:
         return None
     vpxcc = b[0]
-    m_pt = b[1]
+    m_pt = b[1] & 0x7F
     version = (vpxcc >> 6) & 0x03
     if version != 2:
         return None


### PR DESCRIPTION
[TP-10-1Sec13.3b] fix try_parse_rtp() payload type parsing

<img width="1015" height="382" alt="image" src="https://github.com/user-attachments/assets/5980957f-4625-4ad3-955f-cc457cfbb69c" />
